### PR TITLE
Endless loop happens when CPU is busy

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -242,7 +242,7 @@ void limit_process(pid_t pid, double limit, int include_children)
 		}
 
 		//adjust work and sleep time slices
-		if (pcpu < 0) {
+		if (pcpu < 0 || -1 == workingrate) {
 			//it's the 1st cycle, initialize workingrate
 			pcpu = limit;
 			workingrate = limit;


### PR DESCRIPTION
When CPU is busy, then start cpulimit, there will be no sleep in the while loop.
Endless loop may happen.
Endless loop steps
1.	Enter function “limit_process”
2.	Init process group, and update process group, add pgroup element.
3.	Set workingrate = -1, enter while loop
4.	Update process group, this will spend longer time(because other services are using high CPU) to do the update group, so cause “dt < MIN_DT” is false, then get process cpu usage and set the cpu usage value to pgroup process cputime, “cputime” is 0.
5.	Enter “for (node = pgroup.proclist->first; node != NULL; node = node->next)”, set “pcpu = 0”;
6.	Because “pcpu = 0”, so workingrate is set to “-inf”, and twork.tv_nsec is set to “-2147483648”
7.	nanosleep(&twork, NULL);  #tsleep.tv_nsec=0.000000, so there will be no sleep.
8.	“While” loop continues.